### PR TITLE
Fix os.system arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Project
+.vscode/
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -352,4 +352,3 @@ MigrationBackup/
 # Project
 .vscode/
 results/
-dataset-files/

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,4 @@ MigrationBackup/
 # Project
 .vscode/
 results/
+dataset-files/

--- a/.gitignore
+++ b/.gitignore
@@ -348,7 +348,3 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
-
-# Project
-.vscode/
-results/

--- a/main_controller.py
+++ b/main_controller.py
@@ -57,7 +57,7 @@ def script_chooser(arguments):
         print("Probing: TODO\nSkipping...")
     elif (arguments[1] == "s2"): #step 2 - Preprocessing, filters RSSI values (removes everything else from the file)
             try:
-                os.system("./preprocess_input.sh " + arguments[2]) #TODO change the options to be more flexible
+                os.system(f"./preprocess_input.sh {' '.join(arguments[2:])}") #TODO change the options to be more flexible
             except IndexError:
                 print ("E: Not enough arguments were given!\nUsage:\npython3 " + arguments[0] + " " + arguments[1] + " [script args]")
                 print("NOTE: script args are those from the examples below")


### PR DESCRIPTION
When I tried to run the main_controller file in the "s2" option, the following error "not enough arguments" appeared. This happened because when the "preprocess_input.sh" script was called, not all arguments were passed, but rather what was in the "arguments[2]" position, which generated such an error